### PR TITLE
Add Quantifying Coinjoin Twitter Thread Links / Update CoinShuffle Links

### DIFF
--- a/CoinJoin_Implementations/10_CoinShuffle-bryanvu/summary.md
+++ b/CoinJoin_Implementations/10_CoinShuffle-bryanvu/summary.md
@@ -1,10 +1,11 @@
-﻿|               	| 				|
-| ----------- 		| ----------	| 
+|               	| 				|
+| ----------- 		| ----------	|
 | Project Name 		| CoinShuffle 		|
 | Release Date		| 2014–10–01	|
 | Bounty Post 		| [link](Bounty Post)		|
-| Announcement Post | NA		|
+| Announcement Post | [link](https://bitcointalk.org/index.php?topic=567625.0)		|
 | Dev				| Bryan Vu		|
 | GitHub Page		| [server](https://github.com/bryanvu/coinshuffle-server) , [sim](https://github.com/bryanvu/coinshuffle-sim) , [wallet](https://github.com/bryanvu/coinshuffle-wallet)		|
 | Last Commit		| 2014–08–08	|
-| Demo				| [link](https://youtu.be/YDGUUtDqNV0) | 
+| Demo				| [link](https://youtu.be/YDGUUtDqNV0) |
+| Website     | [link](http://crypsys.mmci.uni-saarland.de/projects/CoinShuffle/)  |

--- a/CoinJoin_Research/Theory/Quantifying Coinjoin/README.md
+++ b/CoinJoin_Research/Theory/Quantifying Coinjoin/README.md
@@ -1,0 +1,7 @@
+Quantifying Coinjoin is a series of Twitter threads by [@ErgoBTC](https://twitter.com/ErgoBTC).
+
+Quantifying Coinjoin aims to simplify and review methods for measuring coinjoin quality
+
+Thread #1 - [Why do we need coinjoin? Breaking deterministic links, creating uncertainty, and multiple transaction interpretations.](https://threadreaderapp.com/thread/1161964944897847296.html)
+
+Thread #2 - [What is entropy & how can it be used to evaluate your Bitcoin transaction “privacy”?](https://threadreaderapp.com/thread/1159840505267494912.html)


### PR DESCRIPTION
Added links to Quantifying Coinjoin unrolled Twitter Threads.
Included link to Coinshuffle bitcointalk announcement and website.