### PR TITLE
Remove incorrect trust assumption

### DIFF
--- a/CoinJoin_Research/CoinJoin_FAQ.md
+++ b/CoinJoin_Research/CoinJoin_FAQ.md
@@ -138,7 +138,6 @@ Wasabi consists of a wallet which allows you to receive bitcoin, optionally mix,
 *Note*: BIP 158 is not as good as running your own node. You trust
 - The Wasabi server gives you the correct filters
 - The Wasabi server to not withhold any filters
-- The block you download from a P2P node is actually in the valid chain
 
 ## Whirlpool
 Whirlpool is a mixing tool which extends the functionality of the Samourai Wallet (SW) application for Android to include CoinJoin capabilities.


### PR DESCRIPTION
As you wrote, you trust the Wasabi coordinator with the validity of the filters. If the node gives you the wrong block, then you disconnect the node and acquire the block you wish to acquire from another one, so there's no trust assumption towards random nodes in regards of block downloading.

For the shake of completeness I want to mention that there's currently a trust assumption in terms of unconfirmed txs towards the node for about 10 minutes.  
So your wallet believes every unconfirmed tx that comes from the node, but after every block the wallet gets a mempool filter from the server to kick out these transactions.